### PR TITLE
Remove extra `-dark` from appname in dark_deploy command

### DIFF
--- a/src/@orb.yml
+++ b/src/@orb.yml
@@ -282,7 +282,7 @@ jobs:
           org: <<parameters.org>>
           space: <<parameters.space>>
       - dark_deploy:
-          appname: <<parameters.appname>>-dark
+          appname: <<parameters.appname>>
           manifest: <<parameters.manifest>>
           package: <<parameters.package>>
           domain: <<parameters.domain>>


### PR DESCRIPTION
Without this change, the dark appname ends up with `-dark-dark` at the end. If using the live_deploy subsequently without adding `-dark` to the appname passed, the names do not match and it fails.

Fixes #5